### PR TITLE
Only start post processing if the noExecute flag is false

### DIFF
--- a/src/download/downloader.c
+++ b/src/download/downloader.c
@@ -367,7 +367,7 @@ static char *postProcess(app_t *app, char *file, uint8_t noExecute) {
         char *tmp = str_replace(commandTemplate, "%file%", file);
         command = str_replace(tmp, "%target%", directory);
 
-        if (noExecute) {
+        if (noExecute == 0) {
             int status = system(command);
             LOG_INFO("%s exited with: %d", command, status);
             free(command);


### PR DESCRIPTION
This fixes a bug where the cURL version should await the download to finish before running the post processing script (and vice versa for the internal downloader function), but the opposite was happening.